### PR TITLE
Fix missing string format in streak announcment

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -811,7 +811,7 @@ class SpiffyBattleAnnouncer(SpiffyAnnouncer):
         elif streak_count == 6:
             announcement_msg = "%s is GOD-LIKE!" % unit_name
         elif streak_count == 7:
-            announcement_msg = "BOOMSHAKALAKA! %s is DOMINATING!"
+            announcement_msg = "BOOMSHAKALAKA! %s is DOMINATING!" % unit_name
 
         announcement_msg = self._c(announcement_msg, "light green")
 


### PR DESCRIPTION
While totally destroying a dungeon earlier, I noticed a improperly formatted streak announcement. If it weren't for my wreckage, pwnage, etc., this may have gone unnoticed for quite some time.